### PR TITLE
Switch from github3.py to agithub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 giturlparse
-github3.py
+agithub
 gitpython
 PyYAML
 retrying

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='fork-github-repo',
-    version='1.1.0',
+    version='1.2.0',
     packages=['fork_github_repo'],
     url='https://github.com/gene1wood/fork-github-repo',
     license=' GPL-3.0',


### PR DESCRIPTION
The 1.0 release of github3.py had breaking changes which broke fork-github-repo
Let's get out of the business of using github3.py which has to keep up
with GitHub's API and instead use agithub which doesn't